### PR TITLE
Throw when array and object deletion values do not match current version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+branches:
+  only:
+    - master
+
 language: node_js
 
 node_js:
   - 8
-

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -1,3 +1,5 @@
+var deepEqual = require('fast-deep-equal');
+
 /*
  This is the implementation of the JSON OT type.
 
@@ -181,7 +183,8 @@ json.apply = function(snapshot, op) {
     // List replace
     else if (c.li !== void 0 && c.ld !== void 0) {
       json.checkList(elem);
-      // Should check the list element matches c.ld
+      if (!deepEqual(elem[key], c.ld))
+        throw new Error('List deletion value does not match current value')
       elem[key] = c.li;
     }
 
@@ -194,7 +197,8 @@ json.apply = function(snapshot, op) {
     // List delete
     else if (c.ld !== void 0) {
       json.checkList(elem);
-      // Should check the list element matches c.ld here too.
+      if (!deepEqual(elem[key], c.ld))
+        throw new Error('List deletion value does not match current value')
       elem.splice(key,1);
     }
 
@@ -214,7 +218,8 @@ json.apply = function(snapshot, op) {
     else if (c.oi !== void 0) {
       json.checkObj(elem);
 
-      // Should check that elem[key] == c.od
+      if (!deepEqual(elem[key], c.od))
+        throw new Error('Object deletion value does not match current value')
       elem[key] = c.oi;
     }
 
@@ -222,7 +227,8 @@ json.apply = function(snapshot, op) {
     else if (c.od !== void 0) {
       json.checkObj(elem);
 
-      // Should check that elem[key] == c.od
+      if (!deepEqual(elem[key], c.od))
+        throw new Error('Object deletion value does not match current value')
       delete elem[key];
     }
 
@@ -660,4 +666,3 @@ var text = require('./text0');
 
 json.registerSubtype(text);
 module.exports = json;
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "fast-deep-equal": "^2.0.1"
+  },
   "devDependencies": {
     "ot-fuzzer": "^1.0.0",
     "mocha": "^1.20.1",

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -67,10 +67,14 @@ genTests = (type) ->
 
   # Strings should be handled internally by the text type. We'll just do some basic sanity checks here.
   describe 'string', ->
-    describe '#apply()', -> it 'works', ->
-      assert.deepEqual 'abc', type.apply 'a', [{p:[1], si:'bc'}]
-      assert.deepEqual 'bc', type.apply 'abc', [{p:[0], sd:'a'}]
-      assert.deepEqual {x:'abc'}, type.apply {x:'a'}, [{p:['x', 1], si:'bc'}]
+    describe '#apply()', ->
+      it 'works', ->
+        assert.deepEqual 'abc', type.apply 'a', [{p:[1], si:'bc'}]
+        assert.deepEqual 'bc', type.apply 'abc', [{p:[0], sd:'a'}]
+        assert.deepEqual {x:'abc'}, type.apply {x:'a'}, [{p:['x', 1], si:'bc'}]
+
+      it 'throws when the deletion target does not match', ->
+        assert.throws -> type.apply 'abc', [{p:[0], sd:'x'}]
 
     describe '#transform()', ->
       it 'splits deletes', ->
@@ -126,6 +130,10 @@ genTests = (type) ->
       it 'moves', ->
         assert.deepEqual ['a', 'b', 'c'], type.apply ['b', 'a', 'c'], [{p:[1], lm:0}]
         assert.deepEqual ['a', 'b', 'c'], type.apply ['b', 'a', 'c'], [{p:[0], lm:1}]
+
+      it 'throws when the deletion target does not match', ->
+        assert.throws -> type.apply ['a', 'b', 'c'], [{p:[0], ld: 'x'}]
+        assert.throws -> type.apply ['a', 'b', 'c'], [{p:[0], li: 'd', ld: 'x'}]
 
       ###
       'null moves compose to nops', ->
@@ -388,6 +396,11 @@ genTests = (type) ->
     it 'An attempt to re-delete a key becomes a no-op', ->
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'left'
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'right'
+
+    it 'throws when the deletion target does not match', ->
+      assert.throws -> type.apply {x:'a'}, [{p:['x'], od: 'b'}]
+      assert.throws -> type.apply {x:'a'}, [{p:['x'], oi: 'c', od: 'b'}]
+      assert.throws -> type.apply {x:'a'}, [{p:['x'], oi: 'b'}]
 
   describe 'randomizer', ->
     @timeout 20000


### PR DESCRIPTION
This change adds validation to array and object deletion. If the values
provided in either `ld` or `od` do not match the current value, then
`apply` will `throw`. It will also throw if `oi` overwrites an existing
value without providing `od`.

The primary motivation of this change is to ensure that all submitted
ops remain reversible. At the moment, the following series of ops is
possible:

  - start with `{ foo: 'bar' }`
  - `apply` this op: `{ p: ['foo'], oi: 'baz' }`
  - ...resulting in `{ foo: 'baz' }`
  - `invert` the previous op: `{ p: ['foo'], od: 'baz' }`
  - and `apply` the inverted op: `{}`

When I apply, invert and apply, I should always wind up where I started,
but in this case I clearly do not.

By ensuring that the `od` matches the current value, we make sure that
all ops remain reversible.

Deep equality adds a dependency on [`fast-deep-equal`][1].

[1]: https://github.com/epoberezkin/fast-deep-equal