### PR TITLE
Move to Github Actions

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    default_reviewers:
+      - "alecgibson"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        registry-url: 'https://npm.pkg.github.com'
+    - name: Install
+      run: npm install
+      env:
+        # GITHUB_TOKEN can't access packages hosted in private repos,
+        # even within the same organisation
+        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Publish
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # Use PAT instead of default Github token, because the default
+        # token deliberately will not trigger another workflow run
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+        registry-url: 'https://npm.pkg.github.com'
+    - name: Install
+      run: npm install
+      env:
+        # GITHUB_TOKEN can't access packages hosted in private repos,
+        # even within the same organisation
+        NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+    - name: Test
+      run: npm test
+    - name: Tag
+      if: ${{ github.ref == 'refs/heads/master' }}
+      run: ./tag.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-branches:
-  only:
-    - master
-
-language: node_js
-
-node_js:
-  - 8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ot-json0",
-  "version": "1.1.0",
+  "name": "@reedsy/ot-json0",
+  "version": "1.1.0-reedsy.1.0.0",
   "description": "JSON OT type",
   "main": "lib/index.js",
   "directories": {
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ottypes/json0"
+    "url": "git://github.com/reedsy/json0.git"
   },
   "keywords": [
     "ot",

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+VERSION=$(node -p "require('./package.json').version")
+
+git config --local user.email "github@reedsy.com"
+git config --local user.name "GitHub Action"
+git fetch --tags
+
+VERSION_COUNT=$(git tag --list $VERSION | wc -l)
+
+if [ $VERSION_COUNT -gt 0 ]
+then
+  echo "Version $VERSION already deployed."
+  exit 0
+else
+  echo "Deploying version $VERSION"
+fi
+
+git tag $VERSION
+git push origin refs/tags/$VERSION


### PR DESCRIPTION
This change moves us from Travis to Github Actions, and automatically
deploys packages to Github Packages on a successful build with a new
`package.json` version number.