### PR TITLE
🐛 Fix list deletion presence transformation

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -705,7 +705,10 @@ json.transformPresence = function(presence, op, isOwnOp) {
       delete component.od;
     }
 
-    if ('ld' in component) {
+    // Need to actively check that the list deletion matches
+    // the presence deletion, otherwise we need to keep this
+    // as an ld to correctly transform the path.
+    if ('ld' in component && pathMatches(component.p, presence.p)) {
       component.oi = component.ld;
       delete component.ld;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/ot-json0",
-  "version": "1.1.0-reedsy.1.2.0",
+  "version": "1.1.0-reedsy.1.2.1",
   "description": "JSON OT type",
   "main": "lib/index.js",
   "engines": {

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -482,6 +482,9 @@ genTests = (type) ->
     it 'moves presence indirectly moved by li', ->
       assert.deepEqual {p: ['x', 3], v: 0}, type.transformPresence {p: ['x', 2], v: 0}, [{p: ['x', 0], li: 'foo'}]
 
+    it 'moves presence indirectly moved by ld', ->
+      assert.deepEqual {p: ['x', 1], v: 0}, type.transformPresence {p: ['x', 2], v: 0}, [{p: ['x', 0], ld: 'foo'}]
+
     it 'moves deep presence moved by a higher li', ->
       assert.deepEqual {p: ['x', 3, 'y'], v: 0}, type.transformPresence {p: ['x', 2, 'y'], v: 0}, [{p: ['x', 1], li: 'foo'}]
 


### PR DESCRIPTION
This change fixes a bug where deleting items in a list ahead of your
presence won't correctly transform the presence.

This happens because we change the `ld` to an `oi` to get the correct
behaviour when deleting the actual list item your presence is on.

In order to handle both cases, this change adds a check for the path.
If the path matches the component, then we change it into an `oi` for
the special behaviour, otherwise we leave it so that the `transform()`
works properly.